### PR TITLE
Replace change instead of adding new one

### DIFF
--- a/protocol/vm_context.go
+++ b/protocol/vm_context.go
@@ -63,7 +63,6 @@ func (c *Context) SetContractVariable(index int, value []byte) error {
 	copy(cp, value)
 
 	change := NewChange(index, cp)
-
 	storedChange := c.findChangeByIndex(index)
 
 	if storedChange != nil {
@@ -116,8 +115,7 @@ func (c *Context) GetSig1() [64]byte {
 
 func (c *Context) replaceChange(newChange Change) {
 	for i, change := range c.changes {
-		j,_ := change.GetChange()
-		if j == newChange.index {
+		if change.index == newChange.index {
 			c.changes[i] = newChange
 		}
 	}
@@ -125,8 +123,7 @@ func (c *Context) replaceChange(newChange Change) {
 
 func (c *Context) findChangeByIndex(index int) *Change {
 	for _, change := range c.changes {
-		i, _ := change.GetChange()
-		if i == index {
+		if change.index == index {
 			return &change
 		}
 	}

--- a/protocol/vm_context.go
+++ b/protocol/vm_context.go
@@ -63,7 +63,14 @@ func (c *Context) SetContractVariable(index int, value []byte) error {
 	copy(cp, value)
 
 	change := NewChange(index, cp)
-	c.changes = append(c.changes, change)
+
+	storedChange := c.findChangeByIndex(index)
+	if storedChange != nil {
+		storedChange = &change
+	} else {
+		c.changes = append(c.changes, change)
+	}
+
 	return nil
 }
 

--- a/protocol/vm_context.go
+++ b/protocol/vm_context.go
@@ -67,7 +67,7 @@ func (c *Context) SetContractVariable(index int, value []byte) error {
 	storedChange := c.findChangeByIndex(index)
 
 	if storedChange != nil {
-		c.replaceChangeByIndex(change)
+		c.replaceChange(change)
 	} else {
 		c.changes = append(c.changes, change)
 	}
@@ -114,7 +114,7 @@ func (c *Context) GetSig1() [64]byte {
 	return c.Sig1
 }
 
-func (c *Context) replaceChangeByIndex(newChange Change) {
+func (c *Context) replaceChange(newChange Change) {
 	for i, change := range c.changes {
 		j,_ := change.GetChange()
 		if j == newChange.index {

--- a/protocol/vm_context.go
+++ b/protocol/vm_context.go
@@ -117,6 +117,7 @@ func (c *Context) replaceChange(newChange Change) {
 	for i, change := range c.changes {
 		if change.index == newChange.index {
 			c.changes[i] = newChange
+			return
 		}
 	}
 }

--- a/protocol/vm_context.go
+++ b/protocol/vm_context.go
@@ -65,8 +65,9 @@ func (c *Context) SetContractVariable(index int, value []byte) error {
 	change := NewChange(index, cp)
 
 	storedChange := c.findChangeByIndex(index)
+
 	if storedChange != nil {
-		storedChange = &change
+		c.replaceChangeByIndex(change)
 	} else {
 		c.changes = append(c.changes, change)
 	}
@@ -111,6 +112,15 @@ func (c *Context) GetFee() uint64 {
 
 func (c *Context) GetSig1() [64]byte {
 	return c.Sig1
+}
+
+func (c *Context) replaceChangeByIndex(newChange Change) {
+	for i, change := range c.changes {
+		j,_ := change.GetChange()
+		if j == newChange.index {
+			c.changes[i] = newChange
+		}
+	}
 }
 
 func (c *Context) findChangeByIndex(index int) *Change {

--- a/protocol/vm_context_test.go
+++ b/protocol/vm_context_test.go
@@ -66,3 +66,58 @@ func TestVMContext_SetContractVariable_EncapsulationBreach(t *testing.T) {
 		t.Errorf("Expected result to be '%v' but was '%v'", expected, actual)
 	}
 }
+
+func TestVMContext_SetContractVariable_Simple(t *testing.T) {
+	c := Context{}
+	c.ContractVariables = [][]byte{[]byte{0x00, 0x00, 0x00}}
+
+	slice1, _ := c.GetContractVariable(0)
+
+	// Change values for the first time
+	for i := range slice1 {
+		slice1[i] = 1
+	}
+	c.SetContractVariable(0, slice1)
+
+	c.PersistChanges()
+
+	if len(c.changes) != 1 {
+		t.Errorf("Only 1 change with index 0 expected but got %v", len(c.changes))
+	}
+
+	expected := []byte{0x01, 0x01, 0x01}
+	actual, _ := c.GetContractVariable(0)
+	if !bytes.Equal(expected, actual) {
+		t.Errorf("Expected result to be '%v' but was '%v'", expected, actual)
+	}
+}
+
+func TestVMContext_SetContractVariable_ReplaceChange(t *testing.T) {
+	c := Context{}
+	c.ContractVariables = [][]byte{[]byte{0x00, 0x00, 0x00}}
+
+	slice1, _ := c.GetContractVariable(0)
+
+	// Change values for the first time
+	for i := range slice1 {
+		slice1[i] = 1
+	}
+	c.SetContractVariable(0, slice1)
+
+	// Change values for the second time
+	for i := range slice1 {
+		slice1[i] = 2
+	}
+	c.SetContractVariable(0, slice1)
+	c.PersistChanges()
+
+	if len(c.changes) != 1 {
+		t.Errorf("Only 1 change with index 0 expected but got %v", len(c.changes))
+	}
+
+	expected := []byte{0x02, 0x02, 0x02}
+	actual, _ := c.GetContractVariable(0)
+	if !bytes.Equal(expected, actual) {
+		t.Errorf("Expected result to be '%v' but was '%v'", expected, actual)
+	}
+}

--- a/protocol/vm_context_test.go
+++ b/protocol/vm_context_test.go
@@ -69,55 +69,51 @@ func TestVMContext_SetContractVariable_EncapsulationBreach(t *testing.T) {
 
 func TestVMContext_SetContractVariable_Simple(t *testing.T) {
 	c := Context{}
-	c.ContractVariables = [][]byte{[]byte{0x00, 0x00, 0x00}}
+	c.ContractVariables = [][]byte{{0x00, 0x00, 0x00}}
 
-	slice1, _ := c.GetContractVariable(0)
-
-	// Change values for the first time
-	for i := range slice1 {
-		slice1[i] = 1
-	}
-	c.SetContractVariable(0, slice1)
-
-	c.PersistChanges()
+	newValue := []byte{0x01, 0x01, 0x01}
+	c.SetContractVariable(0, newValue)
 
 	if len(c.changes) != 1 {
 		t.Errorf("Only 1 change with index 0 expected but got %v", len(c.changes))
 	}
 
-	expected := []byte{0x01, 0x01, 0x01}
 	actual, _ := c.GetContractVariable(0)
-	if !bytes.Equal(expected, actual) {
-		t.Errorf("Expected result to be '%v' but was '%v'", expected, actual)
+	if !bytes.Equal(newValue, actual) {
+		t.Errorf("Expected result to be '%v' but was '%v'", newValue, actual)
+	}
+
+	c.PersistChanges()
+	actual = c.ContractVariables[0]
+	if !bytes.Equal(newValue, actual) {
+		t.Errorf("Contract variable should be updated to '%v' but was '%v'", newValue, actual)
 	}
 }
 
 func TestVMContext_SetContractVariable_ReplaceChange(t *testing.T) {
 	c := Context{}
-	c.ContractVariables = [][]byte{[]byte{0x00, 0x00, 0x00}}
-
-	slice1, _ := c.GetContractVariable(0)
+	c.ContractVariables = [][]byte{{0x00, 0x00, 0x00}}
 
 	// Change values for the first time
-	for i := range slice1 {
-		slice1[i] = 1
-	}
-	c.SetContractVariable(0, slice1)
+	newValue1 := []byte{0x01}
+	c.SetContractVariable(0, newValue1)
 
 	// Change values for the second time
-	for i := range slice1 {
-		slice1[i] = 2
-	}
-	c.SetContractVariable(0, slice1)
-	c.PersistChanges()
+	newValue2 := []byte{0x02}
+	c.SetContractVariable(0, newValue2)
 
 	if len(c.changes) != 1 {
 		t.Errorf("Only 1 change with index 0 expected but got %v", len(c.changes))
 	}
 
-	expected := []byte{0x02, 0x02, 0x02}
+	expected := []byte{0x02}
 	actual, _ := c.GetContractVariable(0)
 	if !bytes.Equal(expected, actual) {
 		t.Errorf("Expected result to be '%v' but was '%v'", expected, actual)
+	}
+	c.PersistChanges()
+	actual = c.ContractVariables[0]
+	if !bytes.Equal(newValue2, actual) {
+		t.Errorf("Contract variable should be updated to '%v' but was '%v'", newValue2, actual)
 	}
 }


### PR DESCRIPTION
We need to replace the changes so that only a single change with the same index is stored. Otherwise reading the contract variable results in returning some change. We do not need all changes anyway.